### PR TITLE
Update `ETA Reduction`

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Alpha conversion creates a non-conflicting namespace for proper application to f
 `⋀fun.⋀arg.(fun arg) add 3 |- (add 3)`
 
 ## Eta Reduction
-` ⋀name.(func name) |-  `
+` ⋀name.(func name) |- func`
 
 # Variables
 


### PR DESCRIPTION
Shouldn't  "\x. f x" -> f

```haskell
main :: IO ()
main = (\x -> print x) "Hello"
```

equivalent to

```haskell
main :: IO()
main = print "Hello"
```